### PR TITLE
Feature/fix transient on multisite

### DIFF
--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -113,7 +113,7 @@ class SiteSettings extends AbstractSiteSettings
     /** @return mixed[] */
     public function fetchSettings()
     {
-        $siteSettings = get_transient('site_settings_' . get_current_blog_id());
+        $siteSettings = get_transient('site_settings');
         if ($siteSettings) {
             return $siteSettings;
         }
@@ -121,7 +121,7 @@ class SiteSettings extends AbstractSiteSettings
         $settings = (array)get_fields('option');
         $settings = $this->normalizeSettings($settings);
 
-        set_transient('site_settings_' . get_current_blog_id(), $settings);
+        set_transient('site_settings', $settings);
 
         return $settings;
     }

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -10,8 +10,8 @@ class SiteSettings extends AbstractSiteSettings
 {
     public const ID = 'site-settings';
 
-    /** @var mixed[] */
-    protected $settings;
+    /** @var array<int, mixed[]> */
+    protected $settings = [];
 
     /**
      * @param class-string<ISettingsPage> $class
@@ -148,11 +148,13 @@ class SiteSettings extends AbstractSiteSettings
     /** @return mixed[] */
     public function getSettings()
     {
-        if (!$this->settings) {
-            $this->settings = $this->fetchSettings();
+        $id = get_current_blog_id();
+
+        if (!$this->settings[$id]) {
+            $this->settings[$id] = $this->fetchSettings();
         }
 
-        return $this->settings;
+        return $this->settings[$id];
     }
 
     /**

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -150,7 +150,7 @@ class SiteSettings extends AbstractSiteSettings
     {
         $id = get_current_blog_id();
 
-        if (!$this->settings[$id]) {
+        if (!array_key_exists($id, $this->settings)) {
             $this->settings[$id] = $this->fetchSettings();
         }
 

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -113,7 +113,7 @@ class SiteSettings extends AbstractSiteSettings
     /** @return mixed[] */
     public function fetchSettings()
     {
-        $siteSettings = get_transient('site_settings');
+        $siteSettings = get_transient('site_settings_' . get_current_blog_id());
         if ($siteSettings) {
             return $siteSettings;
         }
@@ -121,7 +121,7 @@ class SiteSettings extends AbstractSiteSettings
         $settings = (array)get_fields('option');
         $settings = $this->normalizeSettings($settings);
 
-        set_transient('site_settings', $settings);
+        set_transient('site_settings_' . get_current_blog_id(), $settings);
 
         return $settings;
     }


### PR DESCRIPTION
As reported by Erik:

Assuming blog 1 and 2 have different 'script_head' settings, currently doing

switch_to_blog(1);
echo setting('scripts_head');
switch_to_blog(2);
echo setting('scripts_head');

Will both return the 'scripts_head' setting of blog 1. This PR fixes this.